### PR TITLE
修改获取回复者用户名和楼层号的正则表达式，兼容小鱼标签(UTags)

### DIFF
--- a/packages/mobile/src/components/PostEditor.vue
+++ b/packages/mobile/src/components/PostEditor.vue
@@ -561,7 +561,7 @@ async function submit() {
 
   item.hideCallUserReplyContent = item.reply_content
   if (item.replyUsers.length === 1) {
-    item.hideCallUserReplyContent = item.reply_content.replace(/@<a href="\/member\/[\s\S]+?<\/a>(\s#[\d]+)?\s(<br>)?/, () => '')
+    item.hideCallUserReplyContent = item.reply_content.replace(/@<a href="\/member\/[\s\S]+?<\/a>(?:<ul [\s\S]+<\/ul>)?(\s#[\d]+)?\s(<br>)?/, () => '')
   }
   console.log('回复', item)
   // loading.value = false

--- a/packages/mobile/src/main.ts
+++ b/packages/mobile/src/main.ts
@@ -317,7 +317,7 @@ function run() {
         let {users, floor} = this.parseReplyContent(item.reply_content)
         item.hideCallUserReplyContent = item.reply_content
         if (users.length === 1) {
-          item.hideCallUserReplyContent = item.reply_content.replace(/@<a href="\/member\/[\s\S]+?<\/a>(\s#[\d]+)?\s(<br>)?/, () => '')
+          item.hideCallUserReplyContent = item.reply_content.replace(/@<a href="\/member\/[\s\S]+?<\/a>(?:<ul [\s\S]+<\/ul>)?(\s#[\d]+)?\s(<br>)?/, () => '')
         }
         item.replyUsers = users
         item.replyFloor = floor
@@ -361,16 +361,10 @@ function run() {
       if (!str) return
       let users: any = []
       let getUsername = (userStr: string) => {
-        let endIndex = userStr.indexOf('">')
-        if (endIndex > -1) {
-          let user: string = userStr.substring(0, endIndex)
-          if (!users.find((i: any) => i === user)) {
-            users.push(user)
-          }
-        }
+        users.push(userStr);
       }
       // str = `@<a hr a> #4 @<a1 href="/member/Eiden1">Eiden1</a1>   @<a href="/member/Eiden111">Eiden21</a> #11   这也是执行阶段，所谓的安装也是程序业务的 setup 。<br>windows 、Android 并没有系统级的 CD-KEY 。`
-      let userReg = /@<a href="\/member\/([\s\S]+?)<\/a>/g
+      let userReg = /@<a href="\/member\/([^'" ]+)/g
       let has = str.matchAll(userReg)
       let res2 = [...has]
       // console.log('总匹配', res2)
@@ -387,7 +381,7 @@ function run() {
       let floor = -1
       //只有@一个人的时候才去查找是否指定楼层号。
       if (users.length === 1) {
-        let floorReg = /@<a href="\/member\/[\s\S]+?<\/a>[\s]+#([\d]+)/g
+        let floorReg = /@<a href="\/member\/[\s\S]+?<\/a>(?:<ul [\s\S]+<\/ul>)?[\s]+#([\d]+)/g
         let hasFloor = str.matchAll(floorReg)
         let res = [...hasFloor]
         // console.log('总匹配', res)

--- a/packages/pc/src/components/PostEditor.vue
+++ b/packages/pc/src/components/PostEditor.vue
@@ -230,7 +230,7 @@ async function submit() {
 
   item.hideCallUserReplyContent = item.reply_content
   if (item.replyUsers.length === 1) {
-    item.hideCallUserReplyContent = item.reply_content.replace(/@<a href="\/member\/[\s\S]+?<\/a>(\s#[\d]+)?\s(<br>)?/, () => '')
+    item.hideCallUserReplyContent = item.reply_content.replace(/@<a href="\/member\/[\s\S]+?<\/a>(?:<ul [\s\S]+<\/ul>)?(\s#[\d]+)?\s(<br>)?/, () => '')
   }
   // console.log('回复', item)
   // loading.value = false

--- a/packages/pc/src/main.ts
+++ b/packages/pc/src/main.ts
@@ -259,7 +259,7 @@ function run() {
         let { users, floor } = this.parseReplyContent(item.reply_content)
         item.hideCallUserReplyContent = item.reply_content
         if (users.length === 1) {
-          item.hideCallUserReplyContent = item.reply_content.replace(/@<a href="\/member\/[\s\S]+?<\/a>(\s#[\d]+)?\s(<br>)?/, () => '')
+          item.hideCallUserReplyContent = item.reply_content.replace(/@<a href="\/member\/[\s\S]+?<\/a>(?:<ul [\s\S]+<\/ul>)?(\s#[\d]+)?\s(<br>)?/, () => '')
         }
         item.replyUsers = users
         item.replyFloor = floor
@@ -302,16 +302,10 @@ function run() {
       if (!str) return
       let users: any = []
       let getUsername = (userStr: string) => {
-        let endIndex = userStr.indexOf('">')
-        if (endIndex > -1) {
-          let user: string = userStr.substring(0, endIndex)
-          if (!users.find((i: any) => i === user)) {
-            users.push(user)
-          }
-        }
+        users.push(userStr);
       }
       // str = `@<a hr a> #4 @<a1 href="/member/Eiden1">Eiden1</a1>   @<a href="/member/Eiden111">Eiden21</a> #11   这也是执行阶段，所谓的安装也是程序业务的 setup 。<br>windows 、Android 并没有系统级的 CD-KEY 。`
-      let userReg = /@<a href="\/member\/([\s\S]+?)<\/a>/g
+      let userReg = /@<a href="\/member\/([^'" ]+)/g
       let has = str.matchAll(userReg)
       let res2 = [...has]
       // console.log('总匹配', res2)
@@ -328,7 +322,7 @@ function run() {
       let floor = -1
       //只有@一个人的时候才去查找是否指定楼层号。
       if (users.length === 1) {
-        let floorReg = /@<a href="\/member\/[\s\S]+?<\/a>[\s]+#([\d]+)/g
+        let floorReg = /@<a href="\/member\/[\s\S]+?<\/a>(?:<ul [\s\S]+<\/ul>)?[\s]+#([\d]+)/g
         let hasFloor = str.matchAll(floorReg)
         let res = [...hasFloor]
         // console.log('总匹配', res)


### PR DESCRIPTION
通过这个修改可以解决启用[🏷️ 小鱼标签 (UTags)](https://greasyfork.org/zh-CN/scripts/460718-utags-add-usertags-to-links)脚本或[🔗 链接助手](https://greasyfork.org/zh-CN/scripts/464541-links-helper)脚本时“楼中楼”无法生效的问题。

用户反馈的问题：

- https://www.v2ex.com/t/1030787#r_14563321
- https://www.v2ex.com/t/983654#r_14273396
- https://github.com/zyronon/V2Next/issues/88

请 review 代码，如果没问题合并一下。
谢谢。