### PR TITLE
修改回复区域元素定位逻辑

### DIFF
--- a/packages/mobile/src/main.ts
+++ b/packages/mobile/src/main.ts
@@ -7,6 +7,25 @@ import {DefaultUser, functions, getDefaultConfig, getDefaultPost} from "@v2next/
 
 let isMobile = !document.querySelector('#Rightbar');
 
+function findReplyBoxMobile(boxs: any) {
+  // 根据内容的元素属性特征定位回复区域
+  for (let i = 1; i < boxs.length; i++) {
+    const box = boxs[i];
+    const cells = box.querySelectorAll ? box.querySelectorAll('.cell') : [];
+    
+    if (cells && cells.length > 0) {
+      const firstCell = cells[0];
+        if (firstCell.querySelector?.('.snow')) {
+          return box;
+        }
+    }
+  }
+  
+  // 回退逻辑
+  console.warn('[V2Next] 无法智能检测回复区域，使用默认位置');
+  return boxs[1];
+}
+
 let $section = document.createElement('section')
 $section.id = 'app'
 
@@ -200,15 +219,12 @@ function run() {
         body.each(function () {
           if (this.id === wrapperClass) {
             boxs = this.querySelectorAll('.box')
-            box = boxs[1]
+            box = findReplyBoxMobile(boxs)
           }
         })
       } else {
         boxs = body.find(`#${wrapperClass} .box`)
-        box = boxs[1]
-        if (box.querySelector('.fa-tags')) {
-          box = boxs[2]
-        }
+        box = findReplyBoxMobile(boxs)
       }
 
       let cells: any = box.querySelectorAll('.cell')
@@ -278,10 +294,8 @@ function run() {
           let box: any
           $(s[0]).each(function () {
             if (this.id === wrapperClass) {
-              box = this.querySelectorAll('.box')[1]
-              if (box.querySelector('.fa-tags')) {
-                box = this.querySelectorAll('.box')[2]
-              }
+              let boxs = this.querySelectorAll('.box')
+              box = findReplyBoxMobile(boxs)
             }
           })
           let cells: any = box!.querySelectorAll('.cell')


### PR DESCRIPTION
## PR预期目的：

- 修复部分帖子评论区无法加载的问题

## 问题描述：
- 由于v2ex网站引入了打赏功能，并且打赏功能组件的位置在评论区组件前，原有的通过固定下标定位评论区的逻辑会在部分帖子中失效。
- zyronon/V2Next#161 
<img width="1920" height="1027" alt="image" src="https://github.com/user-attachments/assets/9d9e5e8f-ba22-4af6-8a40-8b297c065519" />

## 该PR引入的更改：
- 修改原有逻辑，使用评论区内特定元素的属性来进行定位。

---

## 测试：

这边选择了一些帖子作为不同场景的测试样例，已在本地手动测试，未发现问题

帖子作者未启用打赏功能、回复长度较短无需翻页的帖子示例：
https://www.v2ex.com/t/1158691

帖子作者未启用打赏功能、回复长度大于1页的帖子示例：
https://www.v2ex.com/t/1156452

启用了打赏功能、回复长度较短无需翻页的帖子示例：
https://www.v2ex.com/t/1159054

启用了打赏功能、回复长度大于1页的帖子示例：
https://www.v2ex.com/t/1156319

---

有空的话麻烦维护者帮忙Review一下👀，非常感谢！若有不足还请不吝赐教。

Resolves zyronon/V2Next#161 